### PR TITLE
remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "react": "^0.14.8",
-    "react-dom": "^0.14.8",
+    "react-dom": "^0.14.8"
   }
 }


### PR DESCRIPTION
causes `npm install` to error out
